### PR TITLE
If impersonation mail is provided then include it to token key

### DIFF
--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -28,6 +28,11 @@ Tokens = {
     var tokenKey = HTTPJWT._options.email + ':' +
       HTTPJWT._options.scopes.join(',');
 
+    // If impersonation mail is provided then include it to token key.
+    if (HTTPJWT._options.sub) {
+      tokenKey = tokenKey + ':' + HTTPJWT._options.sub;
+    }
+     
     // Check if there is already cached token.
     var cachedToken = this._cache[tokenKey];
 


### PR DESCRIPTION
There is a problem with token caching logic when using impersonation. When token is signed it includes person to impersonate in it, but when it generates tokenKey to find that token it only includes mail(service account) + scopes. Because tokenKey is created this way it will always take a token from first user who booked a meeting which results in wrong user actually booking a meeting. 
Workaround is to clear tokens before every request but this negates any advantage that caching in your library provides.
Fix is to include impersonation account in token generation (if it is provided) as submitted in pull request.

Best regards,

Dino